### PR TITLE
Fix config existence check pointing at wrong plugin directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Config existence check on startup now looks at the plugin's own data folder instead of a leftover template path, so version-mismatch repair and config reload actually run on restart
+
 ## [Initial Release]
 
 ### Added

--- a/src/main/java/dansplugins/democracy/Democracy.java
+++ b/src/main/java/dansplugins/democracy/Democracy.java
@@ -48,7 +48,7 @@ public final class Democracy extends PonderBukkitPlugin {
     @Override
     public void onEnable() {
         // create/load config
-        if (!(new File("./plugins/ExamplePonderPlugin/config.yml").exists())) {
+        if (!(new File("./plugins/Democracy/config.yml").exists())) {
             configService.saveMissingConfigDefaultsIfNotPresent();
         }
         else {


### PR DESCRIPTION
## Summary
- `Democracy.java`'s `onEnable()` checked for `./plugins/ExamplePonderPlugin/config.yml`, a leftover path from a template project, instead of this plugin's own data folder.
- Since that path essentially never exists on a real server, the `else` branch (version-mismatch check + `reloadConfig()`) never ran on second and later startups.
- Fixed the check to look at `./plugins/Democracy/config.yml`, matching the folder documented in `CONFIG.md`.
- Added a CHANGELOG entry under `[Unreleased]`.

## Test plan
- [x] `mvn compile` — clean
- [x] `mvn test` — clean (no test suite exists in this repo yet)
- [ ] Manual: place the built JAR + Medieval Factions JAR in a local Spigot server, start it twice with a version bump in between, confirm `reloadConfig()`/version-mismatch repair now runs on the second start (not verified in this sandbox — no Spigot server available)

Closes #3

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
